### PR TITLE
memory instanceのdump/restoreバグ修正

### DIFF
--- a/include/executor/migrator.h
+++ b/include/executor/migrator.h
@@ -216,6 +216,9 @@ public:
     auto Res = ModInst->getFunc(FuncIdx);
     if (unlikely(!Res)) {
       // spdlog::error(ErrInfo::InfoAST(ASTNodeAttr::Seg_Element));
+      std::cout << "\x1b[31m";
+      std::cout << "ERROR: _restoreIter" << std::endl;
+      std::cout << "\x1b[1m";
       return Unexpect(Res);
     }
     Runtime::Instance::FunctionInstance* FuncInst = Res.value();
@@ -299,9 +302,6 @@ public:
 
       // ModInstがnullの場合
       if (ModName == NULL_MOD_NAME) {
-        // AST::InstrView::iterator From;
-        // uint32_t Locals, VPos, Arity;
-
         Runtime::StackManager::Frame f(nullptr, nullptr, 0, 0, 0);
         FrameStack.push_back(f);
 


### PR DESCRIPTION
```Expect<void> dump(std::string filename) const noexcept {
		for (size_t i = 0; i < Res.value().size(); i++) {
      dataPtrStream << *(Res.value().data() + i);
    }
}

void restore(std::string filename) noexcept {
		std::vector<Byte> byteVec(0);
    int size = 0;
    while (dataPtrStream.get(ch)) {
      byteVec.push_back((Byte)ch);
      size++;
    }
    setBytes(Span<Byte>{byteVec}, 0, 0, size);
}```