### PR TITLE
diff

### DIFF
--- a/lib/executor/engine/engine.cpp
+++ b/lib/executor/engine/engine.cpp
@@ -84,10 +84,10 @@ Executor::runFunction(Runtime::StackManager &StackMgr,
 
       RestoreFlag = false;
       /// restoreしたものが元のものと一致するかtest
-      Migr.dumpIter(StartIt, "restored_");
-      Migr.dumpStackMgrFrame(StackMgr, "restored_");
-      Migr.dumpStackMgrValue(StackMgr, "restored_");
-      std::cout << "Success to dump restore file" << std::endl;
+      // Migr.dumpIter(StartIt, "restored_");
+      // Migr.dumpStackMgrFrame(StackMgr, "restored_");
+      // Migr.dumpStackMgrValue(StackMgr, "restored_");
+      // std::cout << "Success to dump restore file" << std::endl;
 
       end = clock();
       std::cerr << "restore: " << static_cast<double>(end - start) / CLOCKS_PER_SEC * 1000.0 << "[ms]" << "\n";


### PR DESCRIPTION
wasmedge2wamr_measure_perf
```
SQLite:     version 3.41.2
Keys:       16 bytes each
Values:     100 bytes each
Entries:    1000
RawSize:    0.1 MB (estimated)
------------------------------------------------
fillseq      :     389.876 micros/op;
fillseqsync  :     423.503 micros/op;
fillseqbatch :     200.433 micros/op;
fillrandom   :     430.498 micros/op;
fillrandsync :     422.311 micros/op;
fillrandbatch :     235.989 micros/op;
overwrite    :     578.808 micros/op;
overwritebatch :     415.747 micros/op;
readrandom   :     256.070 micros/op;
readseq      :     246.584 micros/op;
fillrand100K :    6261.110 micros/op;
fillseq100K  :    6131.887 micros/op;
readseq      :     120.823 micros/op;
readrand100K :    1338.959 micros/op;

________________________________________________________
Executed in   84.48 secs    fish           external
   usr time   84.40 secs  481.00 micros   84.40 secs
   sys time    0.06 secs  135.00 micros    0.06 secs
```

wasmedge2wamr_measure_perf_2
```
SQLite:     version 3.41.2
Keys:       16 bytes each
Values:     100 bytes each
Entries:    1000
RawSize:    0.1 MB (estimated)
------------------------------------------------
fillseq      :     558.575 micros/op;
fillseqsync  :     596.213 micros/op;
fillseqbatch :     297.521 micros/op;
fillrandom   :     643.072 micros/op;
fillrandsync :     624.800 micros/op;
fillrandbatch :     349.075 micros/op;
overwrite    :     745.736 micros/op;
overwritebatch :     449.737 micros/op;
readrandom   :     285.179 micros/op;
readseq      :     282.750 micros/op;
fillrand100K :    8110.046 micros/op;
fillseq100K  :    8026.838 micros/op;
readseq      :     152.621 micros/op;
readrand100K :    1791.000 micros/op;

________________________________________________________
Executed in  146.44 secs    fish           external
   usr time  146.33 secs  517.00 micros  146.33 secs
   sys time    0.07 secs  145.00 micros    0.07 secs
```